### PR TITLE
Fix for clozure implementation

### DIFF
--- a/src/assemble.lisp
+++ b/src/assemble.lisp
@@ -35,7 +35,6 @@
   (let ((token (transform-sexp-syntax operand)))
     (destructuring-bind (possible-modes value-start value-end)
         (operand-possible-modes-and-value token)
-      (declare (ignore end))
       (let ((stream (make-stream (coerce (subseq token value-start value-end)
                                          '(vector character)))))
         (make-instruction :opcode opcode :value (fetch-literal stream)

--- a/src/parser.lisp
+++ b/src/parser.lisp
@@ -2,7 +2,7 @@
 
 (defun make-stream (text)
   "Make a string displaced onto the given text."
-  (make-array (length text) :element-type 'character
+  (make-array (length text) :element-type 'character :adjustable t
               :displaced-to text :displaced-index-offset 0))
 
 (defun try-fetch (stream regex)


### PR DESCRIPTION
While testing on windows using clozure common lisp, I discovered adjust-array didn't mutate the array, unless it is constructed with ":adjustable t". The behavior without that parameter in the constructor is implementation-defined. Also found an incorrect declaration.
