### PR TITLE
Fixes for quicklisp

### DIFF
--- a/cl-6502.asd
+++ b/cl-6502.asd
@@ -17,9 +17,9 @@
                (:file "opcodes")
                (:file "jit")
                (:file "utils"))
-  :in-order-to ((test-op (test-op cl-6502-test))))
+  :in-order-to ((test-op (test-op cl-6502/test))))
 
-(defsystem #:cl-6502-test
+(defsystem #:cl-6502/test
   :description "A test suite for cl-6502."
   :license "BSD"
   :author "Brit Butler <redline6561@gmail.com>"
@@ -34,8 +34,9 @@
                (:file "opcodes")
                (:file "jit")
                #+sbcl (:file "perf"))
-  :perform (test-op :after (op c)
-                    (uiop:symbol-call :6502-tests 'run!)))
+  :perform (test-op (op c)
+                    (uiop:symbol-call 'fiveam 'run!
+                                      (uiop:find-symbol* '6502-tests '6502-tests))))
 
 (defpackage #:6502-conf (:export #:app-path))
 (defvar 6502-conf::*basedir*

--- a/tests/perf.lisp
+++ b/tests/perf.lisp
@@ -11,7 +11,6 @@
 statistical profiler to observe performance while running the test suite."
   (klaus-init)
   (sb-sprof:with-profiling (:sample-interval 0.001
-                            :alloc-interval 2
                             :max-samples 1000
                             :show-progress t
                             :report :graph


### PR DESCRIPTION
The cl-6502 system is currently broken in Quicklisp.  This pull request fixes the problems.
